### PR TITLE
Bug 1307788 - Implement Developer Tools notification

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -13,6 +13,7 @@ XPCOMUtils.defineLazyModuleGetter(this, "UAOverrider", "chrome://webcompat/conte
 XPCOMUtils.defineLazyModuleGetter(this, "UAOverrides", "chrome://webcompat/content/data/ua_overrides.js");
 
 let overrider;
+let tabUpdateHandler;
 
 function UAEnablePrefObserver() {
   let isEnabled = Services.prefs.getBoolPref(UA_ENABLE_PREF_NAME);
@@ -28,7 +29,7 @@ function UAEnablePrefObserver() {
 function install() {} // eslint-disable-line no-unused-vars
 function uninstall() {} // eslint-disable-line no-unused-vars
 
-function startup() { // eslint-disable-line no-unused-vars
+function startup({webExtension}) {
   // Intentionally set the preference to true on every browser restart to
   // avoid site breakage by accidentally toggled preferences or by leaving
   // it off after debugging a site.
@@ -37,8 +38,33 @@ function startup() { // eslint-disable-line no-unused-vars
 
   overrider = new UAOverrider(UAOverrides);
   overrider.init();
+
+  // Init webExtension to listen tab update status
+  webExtension.startup().then((api) => {
+    const {browser} = api;
+    // tabUpdateHandler receives tab updated event from WebExtension tablog.js
+    // While tab status changes to loading, tablog.js queries this URI is overrided or not.
+    // tabUpdateHandler uses sendResponse sends result to tablog.js
+    // tablog.js can determine to print web console log or not.
+    tabUpdateHandler = function(message, sender, sendResponse) {
+      try {
+        if (overrider) {
+          let uaOverride = overrider.getUAForURI(Services.io.newURI(message.url, null, null));
+          sendResponse({reply: !!uaOverride});
+        }
+      } catch (exception) {
+        sendResponse({reply: false});
+      }
+    };
+
+    browser.runtime.onMessage.addListener(tabUpdateHandler);
+    return;
+  }).catch((reason) => {
+    console.log(reason);
+  });
 }
 
+// TODO: Figure out how to remove listener when bootstrapped addon shutdown
 function shutdown() { // eslint-disable-line no-unused-vars
   Services.prefs.removeObserver(UA_ENABLE_PREF_NAME, UAEnablePrefObserver);
 

--- a/src/install.rdf.in
+++ b/src/install.rdf.in
@@ -28,5 +28,8 @@
     <!-- Front End MetaData -->
     <em:name>Web Compat</em:name>
     <em:description>Urgent post-release fixes for web compatibility.</em:description>
+
+    <!-- Embed WebExtension -->
+    <em:hasEmbeddedWebExtension>true</em:hasEmbeddedWebExtension>
   </Description>
 </RDF>

--- a/src/jar.mn
+++ b/src/jar.mn
@@ -1,3 +1,8 @@
 [features/webcompat@mozilla.org] chrome.jar:
 % content webcompat %content/
   content/  (content/*)
+
+[features/webcompat@mozilla.org] webextension.jar:
+% override webcompat %/
+  manifest.json (webextension/manifest.json)
+  tablog.js (webextension/tablog.js)

--- a/src/webextension/manifest.json
+++ b/src/webextension/manifest.json
@@ -1,0 +1,16 @@
+{
+
+  "description": "WebCompat Go Faster Web Extension",
+  "manifest_version": 2,
+  "name": "webcompat-extension",
+  "version": "1.0",
+
+  "permissions": [
+    "tabs",
+    "<all_urls>"
+  ],
+
+  "background": {
+    "scripts": ["tablog.js"]
+  }
+}

--- a/src/webextension/tablog.js
+++ b/src/webextension/tablog.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const consoleLogScript = 'console.log("The user agent has been overridden for compatibility reasons.");';
+
+/* This function handle tab updates.
+ * While changeInfo.status is loading and there is url
+ * Send tab url to ua_overrider.js to query if needs to print web console log.
+ */
+function handleUpdated(tabId, changeInfo, tabInfo) {
+  if (changeInfo.status === "loading" && changeInfo.url) {
+    chrome.runtime.sendMessage({url: changeInfo.url}, (message) => {
+      if (message.reply) {
+        chrome.tabs.executeScript(tabId, {code: consoleLogScript});
+      }
+    });
+  }
+}
+
+chrome.tabs.onUpdated.addListener(handleUpdated);


### PR DESCRIPTION
Embed a WebExtension to receive tab update event.
While tab is loading and the URL matches override rule,
Injects a javascript to print console log.
Uses chrome.runtime.onMessage to link WebExtension and UAOverrider.