### PR TITLE
Add dummy override for webcompat.com

### DIFF
--- a/src/content/data/ua_overrides.js
+++ b/src/content/data/ua_overrides.js
@@ -39,6 +39,20 @@
  */
 
 const UAOverrides = [ // eslint-disable-line
+  /*
+   * This is a dummy override that applies a Chrome UA to webcompat.com so we
+   * show the Chrome Add-on download instead of the link to addons.mozilla.org.
+   *
+   * This was only put in place to allow QA to test this system addon on an
+   * actual site, since we were not able to find a proper override in time.
+   */
+  {
+    baseDomain: "webcompat.com",
+    uaTransformer: (originalUA) => {
+      let prefix = originalUA.substr(0, originalUA.indexOf(")")+1);
+      return `${prefix} AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36`
+    }
+  }
 ];
 
 this.EXPORTED_SYMBOLS = ["UAOverrides"];


### PR DESCRIPTION
This is a dummy override that overrides the User Agent on webcompat.com to Chromes UA. This results in the Chrome Add-on being offered instead of the Firefox addon. Obviously, this is nothing we want to leave in place when landing to m-c, but QA needs something to test.

r? @MDTsai 