### PR TITLE
Bug 755590 - Add UA override for sites.google.com

### DIFF
--- a/src/content/data/ua_overrides.jsm
+++ b/src/content/data/ua_overrides.jsm
@@ -25,6 +25,23 @@ const UAOverrides = [
       let prefix = originalUA.substr(0, originalUA.indexOf(")") + 1);
       return `${prefix} AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36`;
     }
+  },
+
+  /*
+   *
+   * Bug 755590 - sites.google.com - top bar doesn't show up in Firefox for Android
+   *
+   * Google Sites does show a different top bar template based on the User Agent.
+   * For Fennec, this results in a broken top bar. Appending Chrome and Mobile Safari
+   * identifiers to the UA results in a correct rendering.
+   */
+  {
+    baseDomain: "google.com",
+    applications: ["fennec"],
+    uriMatcher: (uri) => uri.includes("sites.google.com"),
+    uaTransformer: (originalUA) => {
+      return originalUA + " Chrome/68.0.3440.85 Mobile Safari/537.366";
+    }
   }
 ];
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=755590

This simply appends `Chrome/68.0.3440.85 Mobile Safari/537.36` to the UA for Google Sites, which is enough to have the correct header shown. I did a few tests, and it seems to be working as it should. That being said, Google does not like Sites on mobile devices, and you are unable to edit anything, even on Chrome for Android. All you do is a "Please use Chrome" message - even in Chrome. I guess they want people to use desktop browsers.

r? @wisniewskit 