### PR TITLE
Bug 1480710 - m.imgur.com - Build UA override

### DIFF
--- a/src/content/data/ua_overrides.jsm
+++ b/src/content/data/ua_overrides.jsm
@@ -25,6 +25,24 @@ const UAOverrides = [
       let prefix = originalUA.substr(0, originalUA.indexOf(")") + 1);
       return `${prefix} AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36`;
     }
+  },
+
+  /*
+   * Bug 1480710 - m.imgur.com - Build UA override
+   * WebCompat issue #13154 - https://webcompat.com/issues/13154
+   *
+   * imgur returns a 404 for requests to CSS and JS file if requested with a Fennec
+   * User Agent. By removing the Fennec identifies and adding Chrome Mobile's, we
+   * receive the correct CSS and JS files.
+   */
+  {
+    baseDomain: "imgur.com",
+    applications: ["fennec"],
+    uriMatcher: (uri) => uri.includes("m.imgur.com"),
+    uaTransformer: (originalUA) => {
+      let prefix = originalUA.substr(0, originalUA.indexOf(")") + 1);
+      return prefix + " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36";
+    }
   }
 ];
 


### PR DESCRIPTION
This replaces the User Agent for Imgur on Fenenc to something that looks like

```
Mozilla/5.0 (Android 8.0.0; Mobile; rv:63.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
```

Sadly, simply appending some identifies was not enough to convince Imgur to provide us the CSS and JS files, so I had to replae everything after the first parenthesis.

r? @wisniewskit 