### PR TITLE
portalminasnet.com - Override window.sidebar with something falsey

### DIFF
--- a/src/webextension/background.js
+++ b/src/webextension/background.js
@@ -34,6 +34,12 @@ const contentScripts = {
       js: [{file: "injections/js/bug1472081-election.gov.np-window.sidebar-shim.js"}],
       runAt: "document_start",
       allFrames: true
+    },
+    {
+      matches: ["*://portalminasnet.com/*"],
+      js: [{file: "injections/js/bug1482066-portalminasnet.com-window.sidebar-shim.js"}],
+      runAt: "document_start",
+      allFrames: true
     }
   ],
   android: []

--- a/src/webextension/injections/js/bug1482066-portalminasnet.com-window.sidebar-shim.js
+++ b/src/webextension/injections/js/bug1482066-portalminasnet.com-window.sidebar-shim.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/**
+ * portalminasnet.com - Override window.sidebar with something falsey
+ * WebCompat issue #18143 - https://webcompat.com/issues/18143
+ *
+ * This site is blocking onmousedown and onclick if window.sidebar is something
+ * that evaluates to true, rendering the login unusable. This patch overrides
+ * window.sidebar with false, so the blocking event handlers won't get
+ * registered.
+ */
+
+/* globals exportFunction */
+
+Object.defineProperty(window.wrappedJSObject, "sidebar", {
+  get: exportFunction(function() {
+    return false;
+  }, window),
+
+  set: exportFunction(function() {}, window)
+});


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1482066 and https://webcompat.com/issues/18143

The override is identical to the one in #25, but I created a separate file so we do not have to mix comments and inclusion rules, which should make removing an override easier.

r? @wisniewskit 