### PR TITLE
Bug 1484324 - Add console logging to contentScripts for added context and to avoid 100% duplication

### DIFF
--- a/src/webextension/injections/js/bug1452707-window.controllers-shim-ib.absa.co.za.js
+++ b/src/webextension/injections/js/bug1452707-window.controllers-shim-ib.absa.co.za.js
@@ -16,9 +16,11 @@
 
 /* globals exportFunction */
 
+console.info("window.controllers has been shimmed for compatibility reasons. See https://webcompat.com/issues/16401 for details.");
+
 Object.defineProperty(window.wrappedJSObject, "controllers", {
   get: exportFunction(function() {
-    return "window.controllers has been shimmed with a string to get this site's browser detection to work in Firefox 61+.";
+    return true;
   }, window),
 
   set: exportFunction(function() {}, window)

--- a/src/webextension/injections/js/bug1457335-histography.io-ua-change.js
+++ b/src/webextension/injections/js/bug1457335-histography.io-ua-change.js
@@ -11,6 +11,8 @@
 
 /* globals exportFunction */
 
+console.info("The user agent has been overridden for compatibility reasons. See https://webcompat.com/issues/1804 for details.");
+
 const CHROME_UA = navigator.userAgent + " Chrome for WebCompat";
 
 Object.defineProperty(window.navigator.wrappedJSObject, "userAgent", {

--- a/src/webextension/injections/js/bug1472075-bankofamerica.com-ua-change.js
+++ b/src/webextension/injections/js/bug1472075-bankofamerica.com-ua-change.js
@@ -13,6 +13,8 @@
 /* globals exportFunction */
 
 if (!navigator.platform.includes("Win")) {
+  console.info("The user agent has been overridden for compatibility reasons. See https://webcompat.com/issues/2787 for details.");
+
   const WINDOWS_UA = navigator.userAgent.replace(/\(.*; rv:/i, "(Windows NT 10.0; Win64; x64; rv:");
 
   Object.defineProperty(window.navigator.wrappedJSObject, "userAgent", {

--- a/src/webextension/injections/js/bug1472081-election.gov.np-window.sidebar-shim.js
+++ b/src/webextension/injections/js/bug1472081-election.gov.np-window.sidebar-shim.js
@@ -12,6 +12,8 @@
 
 /* globals exportFunction */
 
+console.info("window.sidebar has been shimmed for compatibility reasons. See https://webcompat.com/issues/11622 for details.");
+
 Object.defineProperty(window.wrappedJSObject, "sidebar", {
   get: exportFunction(function() {
     return false;

--- a/src/webextension/injections/js/bug1482066-portalminasnet.com-window.sidebar-shim.js
+++ b/src/webextension/injections/js/bug1482066-portalminasnet.com-window.sidebar-shim.js
@@ -12,6 +12,8 @@
 
 /* globals exportFunction */
 
+console.info("window.sidebar has been shimmed for compatibility reasons. See https://webcompat.com/issues/18143 for details.");
+
 Object.defineProperty(window.wrappedJSObject, "sidebar", {
   get: exportFunction(function() {
     return false;


### PR DESCRIPTION
This PR adds a console.info statement to all content scripts to

1. Add a note that something has been changed, similar to what we do with UA overrides
2. Provide more context if someone stumbles upon it
3. Make all overrides unique because https://bugzilla.mozilla.org/show_bug.cgi?id=1484324 is an issue. I think this is a nice workaround.

r? @miketaylr 