### PR TITLE
Bug 1486885 - Remove error logging inside getBaseDomainFromURI()

### DIFF
--- a/src/content/lib/ua_overrider.jsm
+++ b/src/content/lib/ua_overrider.jsm
@@ -88,8 +88,7 @@ class UAOverrider {
   getBaseDomainFromURI(uri) {
     try {
       return Services.eTLD.getBaseDomain(uri);
-    } catch (ex) {
-      console.error(`Could not getBaseDomain() for "${uri}"`, ex);
+    } catch (_) {
       return false;
     }
   }


### PR DESCRIPTION
According to [bug 1486885](https://bugzilla.mozilla.org/show_bug.cgi?id=1486885), this causes log traffic in some tests. I did some reading, and couldn't find any cases where this could fail and we do not want it to fail, so it's okay to just each this exception.

r? @miketaylr 