### PR TITLE
PoC for shimming ::-webkit-scrollbar

### DIFF
--- a/src/webextension/background.js
+++ b/src/webextension/background.js
@@ -40,7 +40,12 @@ const contentScripts = {
       js: [{file: "injections/js/bug1482066-portalminasnet.com-window.sidebar-shim.js"}],
       runAt: "document_start",
       allFrames: true
-    }
+    },
+    {
+      matches: ["https://gitter.im/*"],
+      js: [{file: "injections/js/bug1432935-webkit-scrollbar-display-none.js"}],
+      runAt: "document_end",
+    },
   ],
   android: []
 };

--- a/src/webextension/injections/js/bug1432935-webkit-scrollbar-display-none.js
+++ b/src/webextension/injections/js/bug1432935-webkit-scrollbar-display-none.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const WEBKIT_SCROLLBAR = "::-webkit-scrollbar";
+
+let docForParsing;
+function parseStylesheet(content) {
+  if (!docForParsing) {
+    docForParsing = document.implementation.createHTMLDocument();
+  }
+  let style = docForParsing.createElement("style");
+  style.textContent = content;
+  docForParsing.head.appendChild(style);
+  let sheet = style.sheet;
+  style.remove();
+  return sheet;
+}
+
+async function scrollbarSelectors(sheet) {
+  if (sheet.disabled) {
+    return;
+  }
+  // TODO sheet.media?
+
+  let rules;
+  try {
+    rules = sheet.cssRules;
+  } catch (e) {
+    let resp = await fetch(sheet.href);
+    let content = await resp.text();
+    let newSheet = parseStylesheet(content);
+    rules = newSheet.cssRules;
+  }
+  return function*() {
+    for (let rule of rules) {
+      if (rule.type == CSSRule.STYLE_RULE) {
+        // TODO support other style?
+        if (rule.style.display == "none") {
+          // TODO don't break inside parens.
+          let selectors = rule.selectorText.split(",");
+          for (let selector of selectors) {
+            selector = selector.trim();
+            if (selector.endsWith(WEBKIT_SCROLLBAR)) {
+              // TODO if the result selector ends with a combinator,
+              // a universal selectors should be added.
+              selector = selector.slice(0, -WEBKIT_SCROLLBAR.length);
+              yield selector;
+            }
+          }
+        }
+      }
+      // TODO @media / @support?
+    }
+  }();
+}
+
+async function run() {
+  let sheets = [];
+  for (let sheet of document.styleSheets) {
+    sheets.push(scrollbarSelectors(sheet));
+  }
+  let selectors = [];
+  for (let sheet of sheets) {
+    let rules = await sheet;
+    selectors.push(...rules);
+  }
+
+  let style = document.createElement("style");
+  style.textContent = selectors.join(", ") + " { scrollbar-width: none; }";
+  document.head.appendChild(style);
+}
+
+run();


### PR DESCRIPTION
This PR is **not** intended to be merged.

It's just a proof of concept to show a possible way to shim `::-webkit-scrollbar` support with the new scrollbar properties. It should even be possible to simulate the whole webkit scrollbar stuff to some extend (requiring inserting more elements and script into the document). This can be done if necessary, but I tend not to do this at all.

(Note that this currently requires enabling both `layout.css.scrollbar-width.enabled` and `layout.css.unknown-webkit-pseudo-element` on Nightly to take effect.)

Once we ship the scrollbar properties, it shouldn't be too hard for websites to switch for some common usecases (coloring scrollbar or having thinner scrollbar). For more advanced usecases, it should be easy to build encapsulated component to do. So hopefully we would never need something like this.