### PR TITLE
Add lots of UA Overrides

### DIFF
--- a/src/ua_overrides.js
+++ b/src/ua_overrides.js
@@ -171,6 +171,18 @@ const UAOverrides = {
         return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
       },
     },
+
+    /*
+     * Bug 969844 - mobile.de sends desktop site to Firefox on Android
+     *
+     * mobile.de sends the desktop site to Fennec. Spooing as Chrome works fine.
+     */
+    {
+      matches: ["*://*.mobile.de/*"],
+      uaTransformer: (_) => {
+        return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
+      },
+    },
   ],
 };
 

--- a/src/ua_overrides.js
+++ b/src/ua_overrides.js
@@ -95,6 +95,20 @@ const UAOverrides = {
         return "Mozilla/5.0 (Linux; Android 5.0.2; Galaxy Nexus Build/IMM76B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36";
       },
     },
+
+    /*
+     * Bug 1177298 - Write UA overrides for top Japanese Sites
+     * (Imported from ua-update.json.in)
+     *
+     * To receive the proper mobile version instead of the desktop version or
+     * a lower grade mobile experience, the UA is spoofed.
+     */
+    {
+      matches: ["*://*.nhk.or.jp/*"],
+      uaTransformer: (originalUA) => {
+        return originalUA + " AppleWebKit";
+      },
+    },
   ],
 };
 

--- a/src/ua_overrides.js
+++ b/src/ua_overrides.js
@@ -183,6 +183,21 @@ const UAOverrides = {
         return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
       },
     },
+
+    /*
+     * Bug 1476436 - mobile.bet365.com - add UA override for fennec
+     * WebCompat issue #17010 - https://webcompat.com/issues/17010
+     *
+     * mobile.bet365.com serves fennec a alternative version with less interactive
+     * elements, although they work just fine. Spoofing as Chrome makes the
+     * interative elements appear.
+     */
+    {
+      matches: ["*://mobile.bet365.com/*"],
+      uaTransformer: (_) => {
+        return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
+      },
+    },
   ],
 };
 

--- a/src/ua_overrides.js
+++ b/src/ua_overrides.js
@@ -123,6 +123,20 @@ const UAOverrides = {
         return originalUA + " Mobile Safari";
       },
     },
+
+    /*
+     * Bug 1338260 - Add UA override for directTV
+     * (Imported from ua-update.json.in)
+     *
+     * DirectTV has issues with scrolling and cut-off images. Pretending to be
+     * Chrome for Android fixes those issues.
+     */
+    {
+      matches: ["*://*.directv.com/*"],
+      uaTransformer: (_) => {
+        return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
+      },
+    },
   ],
 };
 

--- a/src/ua_overrides.js
+++ b/src/ua_overrides.js
@@ -81,6 +81,20 @@ const UAOverrides = {
         return "Mozilla/5.0 (Linux; Android 5.0.2; Galaxy Nexus Build/IMM76B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36";
       },
     },
+
+    /*
+     * Bug 1177298 - Write UA overrides for top Japanese Sites
+     * (Imported from ua-update.json.in)
+     *
+     * To receive the proper mobile version instead of the desktop version or
+     * a lower grade mobile experience, the UA is spoofed.
+     */
+    {
+      matches: ["*://*.lohaco.jp/*"],
+      uaTransformer: (_) => {
+        return "Mozilla/5.0 (Linux; Android 5.0.2; Galaxy Nexus Build/IMM76B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36";
+      },
+    },
   ],
 };
 

--- a/src/ua_overrides.js
+++ b/src/ua_overrides.js
@@ -109,6 +109,20 @@ const UAOverrides = {
         return originalUA + " AppleWebKit";
       },
     },
+
+    /*
+     * Bug 1177298 - Write UA overrides for top Japanese Sites
+     * (Imported from ua-update.json.in)
+     *
+     * To receive the proper mobile version instead of the desktop version or
+     * a lower grade mobile experience, the UA is spoofed.
+     */
+    {
+      matches: ["*://*.uniqlo.com/*"],
+      uaTransformer: (originalUA) => {
+        return originalUA + " Mobile Safari";
+      },
+    },
   ],
 };
 

--- a/src/ua_overrides.js
+++ b/src/ua_overrides.js
@@ -137,6 +137,19 @@ const UAOverrides = {
         return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
       },
     },
+
+    /*
+     * Bug 1385206 - Create UA override for rakuten.co.jp on Firefox Android
+     * (Imported from ua-update.json.in)
+     *
+     * rakuten.co.jp serves a Desktop version if Firefox is included in the UA.
+     */
+    {
+      matches: ["*://*.rakuten.co.jp/*"],
+      uaTransformer: (originalUA) => {
+        return originalUA.replace(/Firefox.+$/, "");
+      },
+    },
   ],
 };
 

--- a/src/ua_overrides.js
+++ b/src/ua_overrides.js
@@ -150,6 +150,27 @@ const UAOverrides = {
         return originalUA.replace(/Firefox.+$/, "");
       },
     },
+
+    /*
+     * Bug 1483233 - Add a mobile UA override for ebay
+     * (Imported from ua-update.json.in)
+     *
+     * eBays systems have an issue where Fenenc gets sent into an endless
+     * redirect, rendering it completely unusable.
+     */
+    {
+      matches: [
+        "*://*.ebay.at/*", "*://*.ebay.be/*", "*://*.ebay.ca/*", "*://*.ebay.ch/*",
+        "*://*.ebay.cn/*", "*://*.ebay.co.th/*", "*://*.ebay.co.uk/*", "*://*.ebay.com.au/*",
+        "*://*.ebay.com.hk/*", "*://*.ebay.com.my/*", "*://*.ebay.com.sg/*", "*://*.ebay.com.tw/*",
+        "*://*.ebay.com/*", "*://*.ebay.de/*", "*://*.ebay.es/*", "*://*.ebay.fr/*",
+        "*://*.ebay.ie/*", "*://*.ebay.in/*", "*://*.ebay.it/*", "*://*.ebay.nl/*",
+        "*://*.ebay.ph/*", "*://*.ebay.pl/*", "*://*.ebay.vn/*",
+      ],
+      uaTransformer: (_) => {
+        return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
+      },
+    },
   ],
 };
 

--- a/src/ua_overrides.js
+++ b/src/ua_overrides.js
@@ -67,6 +67,20 @@ const UAOverrides = {
         return originalUA + " AppleWebKit/537.36 (KHTML, like Gecko)";
       },
     },
+
+    /*
+     * Bug 1177298 - Write UA overrides for top Japanese Sites
+     * (Imported from ua-update.json.in)
+     *
+     * To receive the proper mobile version instead of the desktop version or
+     * a lower grade mobile experience, the UA is spoofed.
+     */
+    {
+      matches: ["*://weather.yahoo.co.jp/*"],
+      uaTransformer: (_) => {
+        return "Mozilla/5.0 (Linux; Android 5.0.2; Galaxy Nexus Build/IMM76B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36";
+      },
+    },
   ],
 };
 


### PR DESCRIPTION
This PR includes 9 additional UA Overrides for us to ship.

* 7 of them are simply imports from `ua-update.json.in` so we eventually can remove the old mechanism.
* The mobile.de override is tracked in [bug 969844](https://bugzilla.mozilla.org/show_bug.cgi?id=969844).
* The mobile.bet365.com override is tracked in [bug 1476436](https://bugzilla.mozilla.org/show_bug.cgi?id=1476436).

Testing these in current Fennec nightlies can be hard, as `web-ext` is not supporting them right now, see https://github.com/mozilla/web-ext/pull/1391. However, testing in Beta works just fine, and so does compiling Fennec yourself. When testing the `ua-update.json.in` ports, be sure to toggle `general.useragent.site_specific_overrides` and `general.useragent.updates.enabled` to false to disable the old mechanism.

r? @wisniewskit 