### PR TITLE
Documentation adjustments

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -125,16 +125,6 @@ task("export-xpi", ["build"], {async: true}, () => {
   return jake.exec(`cd ${BUILD_DIR}; zip -r webcompat.xpi *`, complete);
 });
 
-desc("Exports and runs the addon inside mozilla-central");
-task("run-mc", ["export-mc"], {async: true}, () => {
-  let mcLocation = getMozillaCentralLocation();
-  jake.exec(
-    `cd ${mcLocation}; ./mach build; ./mach run`,
-    {printStdout: true},
-    complete
-  );
-});
-
 desc("Runs automated tests");
 task("test", ["export-mc"], {async: true}, () => {
   let mcLocation = getMozillaCentralLocation();

--- a/README.md
+++ b/README.md
@@ -31,8 +31,25 @@ dependencies with `npm install`.
 
 ### Run the changed extension sources
 
-1. Run `npm run jake run-mc`
+#### Via `about:debugging`
+
+If you want to debug this extension on recent Desktop versions, you can use
+`about:debugging`:
+
+1. Open `about:debugging` in Firefox
+2. Click the `Load Temporary Add-on...` button
+3. Select `./src/manifest.json` and hit open.
+4. Test!
+
+#### Via `web-ext`
+
+For Fennec, `about:debugging` is not an option. To test Fennec:
+
+1. Run `npm start`
 2. Test!
+
+`npm start` calls (`web-ext`)[https://github.com/mozilla/web-ext], check their
+documentation for available parameters, including debugging options.
 
 ### Building `webcompat.xpi`
 

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   },
   "devDependencies": {
     "eslint": "3.19.0",
-    "eslint-plugin-json": "^1.2.0",
-    "eslint-plugin-mocha": "^4.11.0",
-    "eslint-plugin-mozilla": "^0.4.2",
+    "eslint-plugin-json": "^1.2.1",
+    "eslint-plugin-mocha": "^4.12.1",
+    "eslint-plugin-mozilla": "^0.4.10",
     "eslint-plugin-no-unsanitized": "2.0.1",
-    "eslint-plugin-promise": "^3.5.0",
-    "jake": "^8.0.12",
+    "eslint-plugin-promise": "^3.8.0",
+    "jake": "^8.0.19",
     "web-ext": "^2.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "version": "3.0.0",
   "scripts": {
     "jake": "./node_modules/.bin/jake",
-    "lint": "./node_modules/.bin/eslint src/"
+    "lint": "./node_modules/.bin/eslint src/",
+    "start": "./node_modules/.bin/web-ext run --source-dir src/"
   },
   "devDependencies": {
     "eslint": "3.19.0",
@@ -16,6 +17,7 @@
     "eslint-plugin-mozilla": "^0.4.2",
     "eslint-plugin-no-unsanitized": "2.0.1",
     "eslint-plugin-promise": "^3.5.0",
-    "jake": "^8.0.12"
+    "jake": "^8.0.12",
+    "web-ext": "^2.9.1"
   }
 }


### PR DESCRIPTION
As we are a webextension now, running the extension is simpler. For desktop, `about:debugging` is the way to go, and for mobile, using `web-ext` is simpler than running in a self-built Fennec all the time. This PR adjusts the readme accordingly.

The second commit is just updating the dev dependencies. I figured I could do that if I'm on it anyway. :)

r? @wisniewskit 