### PR TITLE
Add interventions for initial rollout test

### DIFF
--- a/src/injections.js
+++ b/src/injections.js
@@ -41,6 +41,10 @@ const contentScripts = {
       runAt: "document_start",
       allFrames: true,
     },
+    {
+      matches: ["*://*.sreedharscce.in/authenticate"],
+      css: [{file: "injections/css/bug1526977-sreedharscce.in-login-fix.css"}]
+    },
   ],
   android: [
     {

--- a/src/injections/css/bug1526977-sreedharscce.in-login-fix.css
+++ b/src/injections/css/bug1526977-sreedharscce.in-login-fix.css
@@ -1,0 +1,12 @@
+/**
+ * sreedharscce.in - Fix login form with CSS intervention
+ * Bug #1526977 - https://bugzilla.mozilla.org/show_bug.cgi?id=1526977
+ * WebCompat issue #21505 - https://webcompat.com/issues/21505
+ *
+ * The login form is partly moved out of the screen on sreedharscce.in in
+ * Firefox. Enforcing the body height to the full viewport fixes this issue,
+ * as the login form itself is posititoned with `position: absolute;`.
+ */
+body {
+  height: 100vh;
+}

--- a/src/ua_overrides.js
+++ b/src/ua_overrides.js
@@ -266,6 +266,28 @@ const UAOverrides = {
         return UAHelpers.getPrefix(originalUA) + " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
       },
     },
+
+    /*
+     * Bug 1518625 - rottentomatoes.com - Add UA override for videos on www.rottentomatoes.com
+     *
+     * The video framework loaded in via pdk.theplatform.com fails to
+     * acknowledge that Firefox does support HLS, so it fails to find a
+     * supported video format and shows the loading bar forever. Spoofing as
+     * Chrome works.
+     *
+     * Contrary to other PDK sites, rottentomatoes sometimes uses an iFrame to
+     * player.theplatform.com to show a video, so we need to override that domain
+     * as well.
+     */
+    {
+      matches: [
+        "*://*.rottentomatoes.com/*",
+        "*://player.theplatform.com/*",
+      ],
+      uaTransformer: (_) => {
+        return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
+      },
+    },
   ],
 };
 


### PR DESCRIPTION
As discussed, here are two site interventions for us to roll out in our initial test:

* [Bug 1526977](https://bugzilla.mozilla.org/show_bug.cgi?id=1526977) - sreedharscce.in - Fix login form with CSS intervention (see https://github.com/webcompat/web-bugs/issues/21505)
* [Bug 1518625](https://bugzilla.mozilla.org/show_bug.cgi?id=1518625) - Add UA override for rottentomatoes.com

r? @wisniewskit 
cc @adamopenweb 