### PR TITLE
Multiple bugs - Address two ::-webkit-scrollbar cases

### DIFF
--- a/src/injections.js
+++ b/src/injections.js
@@ -93,6 +93,15 @@ for (const injection of [
       matches: ["*://*.twitch.tv/*"],
       css: [{file: "injections/css/bug1518781-twitch.tv-webkit-scrollbar.css"}],
     },
+  }, {
+    id: "bug1305028",
+    platform: "desktop",
+    domain: "gaming.youtube.com",
+    bug: "1305028",
+    contentScripts: {
+      matches: ["*://gaming.youtube.com/*"],
+      css: [{file: "injections/css/bug1305028-gaming.youtube.com-webkit-scrollbar.css"}],
+    },
   },
 ]) {
   Injections.push(injection);

--- a/src/injections.js
+++ b/src/injections.js
@@ -84,6 +84,15 @@ for (const injection of [
       matches: ["*://*.sreedharscce.in/authenticate"],
       css: [{file: "injections/css/bug1526977-sreedharscce.in-login-fix.css"}],
     },
+  }, {
+    id: "bug1518781",
+    platform: "desktop",
+    domain: "twitch.tv",
+    bug: "1518781",
+    contentScripts: {
+      matches: ["*://*.twitch.tv/*"],
+      css: [{file: "injections/css/bug1518781-twitch.tv-webkit-scrollbar.css"}],
+    },
   },
 ]) {
   Injections.push(injection);

--- a/src/injections/css/bug1305028-gaming.youtube.com-webkit-scrollbar.css
+++ b/src/injections/css/bug1305028-gaming.youtube.com-webkit-scrollbar.css
@@ -1,0 +1,14 @@
+/**
+ * gaming.youtube.com - The vertical scrollbar displayed for the main pane is
+ * partially overlapped by the video itself
+ * Bug #1305028 - https://bugzilla.mozilla.org/show_bug.cgi?id=1305028
+ *
+ * The scrollbar in the main player area is overlapped by the player, making the
+ * design look broken. In Chrome, YouTube is using ::-webkit-scrollbar to style
+ * the bar to match their expectations, but this doesn't work in Firefox.
+ * To make it look less broken, we hide the scrollbar for the main video pane
+ * entirely.
+ */
+ytg-scroll-pane.ytg-watch-page {
+  scrollbar-width: none;
+}

--- a/src/injections/css/bug1518781-twitch.tv-webkit-scrollbar.css
+++ b/src/injections/css/bug1518781-twitch.tv-webkit-scrollbar.css
@@ -1,0 +1,14 @@
+/**
+ * twitch.tv - Comment interaction button is overlayed by scrollbar
+ * Bug #1518781 - https://bugzilla.mozilla.org/show_bug.cgi?id=1518781
+ *
+ * The interaction buttons in Twitch' chat are partly overlayed by the
+ * scrollbar, which makes them hard to use. Twitch uses
+ * ::-webkit-scrollbar to make the scrollbar thinner, which isn't working in
+ * Firefox.
+ * Given that even scrollbar-width: thin; is not enough (see Bugzilla), let's
+ * remove it entirely.
+ */
+.video-chat__message-list-wrapper {
+  scrollbar-width: none;
+}


### PR DESCRIPTION
As a Proof-of-Concept, let's address two cases of broken layouts caused by the use of `::-webkit-scrollbar`. This PR contains interventions for two sites:

* [Bug 1305028](https://bugzilla.mozilla.org/show_bug.cgi?id=1305028): Here, the intervention hides the scrollbar in the main player section only. YouTube is using `::-webkit-scrollbar` to make all scrollbars on the site a fixed width, but as far as I can tell, only the main player area scrollbar is an issue, because it gets partly overlapped by the video player.
* [Bug 1518781](https://bugzilla.mozilla.org/show_bug.cgi?id=1518781): The scrollbar prevents users to click on the three-dot-button to access chat message interactions reliably. As discussed in scrollbar, setting the width to `thin` is not enough, so this intervention removes the scroll bar there.

r? @wisniewskit 