### PR TITLE
Add testbed interventions for manual verification.

### DIFF
--- a/src/about-compat/aboutCompat.js
+++ b/src/about-compat/aboutCompat.js
@@ -6,6 +6,9 @@
 
 /* globals browser */
 
+let availablePatches;
+let showHidden = false;
+
 const portToAddon = (function() {
   let port;
 
@@ -69,7 +72,8 @@ Promise.all([
     }
   });
 
-  redraw(info);
+  availablePatches = info;
+  redraw();
 });
 
 function onMessageFromAddon(msg) {
@@ -94,13 +98,17 @@ function onMessageFromAddon(msg) {
   button.disabled = !!msg.toggling;
 }
 
-function redraw(info) {
-  const { overrides, interventions } = info;
-  redrawTable($("#overrides"), overrides);
-  redrawTable($("#interventions"), interventions);
+function redraw() {
+  if (!availablePatches) {
+    return;
+  }
+  const { overrides, interventions } = availablePatches;
+  const showHidden = location.hash === "#all";
+  redrawTable($("#overrides"), overrides, showHidden);
+  redrawTable($("#interventions"), interventions, showHidden);
 }
 
-function redrawTable(table, data) {
+function redrawTable(table, data, showHidden = false) {
   const df = document.createDocumentFragment();
   table.querySelectorAll("tr").forEach(tr => {
     tr.remove();
@@ -128,6 +136,10 @@ function redrawTable(table, data) {
   }
 
   for (const row of data) {
+    if (row.hidden && !showHidden) {
+      continue;
+    }
+
     const tr = document.createElement("tr");
     tr.setAttribute("data-id", row.id);
     df.appendChild(tr);
@@ -156,3 +168,5 @@ function redrawTable(table, data) {
   }
   table.appendChild(df);
 }
+
+window.onhashchange = redraw;

--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -14,6 +14,26 @@
  */
 const AVAILABLE_INJECTIONS = [
   {
+    id: "testbed-injection",
+    platform: "all",
+    domain: "webcompat-addon-testbed.herokuapp.com",
+    bug: "0000000",
+    contentScripts: {
+      matches: ["*://webcompat-addon-testbed.herokuapp.com/*"],
+      css: [
+        {
+          file: "injections/css/bug0000000-testbed-css-injection.css",
+        },
+      ],
+      js: [
+        {
+          file: "injections/js/bug0000000-testbed-js-injection.js",
+        },
+      ],
+      runAt: "document_start",
+    },
+  },
+  {
     id: "bug1452707",
     platform: "desktop",
     domain: "ib.absa.co.za",

--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -18,6 +18,7 @@ const AVAILABLE_INJECTIONS = [
     platform: "all",
     domain: "webcompat-addon-testbed.herokuapp.com",
     bug: "0000000",
+    hidden: true,
     contentScripts: {
       matches: ["*://webcompat-addon-testbed.herokuapp.com/*"],
       css: [

--- a/src/data/ua_overrides.js
+++ b/src/data/ua_overrides.js
@@ -18,6 +18,7 @@ const AVAILABLE_UA_OVERRIDES = [
     platform: "all",
     domain: "webcompat-addon-testbed.herokuapp.com",
     bug: "0000000",
+    hidden: true,
     config: {
       matches: ["*://webcompat-addon-testbed.herokuapp.com/*"],
       uaTransformer: originalUA => {

--- a/src/data/ua_overrides.js
+++ b/src/data/ua_overrides.js
@@ -14,6 +14,21 @@
  */
 const AVAILABLE_UA_OVERRIDES = [
   {
+    id: "testbed-override",
+    platform: "all",
+    domain: "webcompat-addon-testbed.herokuapp.com",
+    bug: "0000000",
+    config: {
+      matches: ["*://webcompat-addon-testbed.herokuapp.com/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36 for WebCompat"
+        );
+      },
+    },
+  },
+  {
     /*
      * Bug 1563839 - rolb.santanderbank.com - Build UA override
      * WebCompat issue #33462 - https://webcompat.com/issues/33462

--- a/src/injections/css/bug0000000-testbed-css-injection.css
+++ b/src/injections/css/bug0000000-testbed-css-injection.css
@@ -1,0 +1,3 @@
+#css-injection.red {
+  background-color: #0f0;
+}

--- a/src/injections/js/bug0000000-testbed-js-injection.js
+++ b/src/injections/js/bug0000000-testbed-js-injection.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/* globals exportFunction */
+
+Object.defineProperty(window.wrappedJSObject, "isTestFeatureSupported", {
+  get: exportFunction(function() {
+    return true;
+  }, window),
+
+  set: exportFunction(function() {}, window),
+});

--- a/src/lib/about_compat_broker.js
+++ b/src/lib/about_compat_broker.js
@@ -40,8 +40,8 @@ class AboutCompatBroker {
     return overrides
       .filter(override => override.availableOnPlatform)
       .map(override => {
-        const { id, active, bug, domain } = override;
-        return { id, active, bug, domain };
+        const { id, active, bug, domain, hidden } = override;
+        return { id, active, bug, domain, hidden };
       });
   }
 


### PR DESCRIPTION
This re-adds the manual verification testbed as we've discussed yesterday. It points to [the new testbed](https://github.com/mozilla/webcompat-addon-testbed/), which is auto-deployed and can be managed by the entire team, so there no longer is a dependency or a reference to my private infrastructure in there. 🎉 

My commit is complete, but I'd like this PR to contain a second commit that blacklists the test interventions from `about:config`. @wisniewskit, I pushed this as a branch on this repo, `testbed-interventions`, please feel free to push your commit doing the blacklisting into the branch whenever you have time to do so. :)