### PR TITLE
Add prettier.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ For Fennec, `about:debugging` is not an option. To test Fennec:
 1. Run `npm run test`
 2. Wait!
 
+### Automatically check and adjust the code style
+
+As `mozilla-central` is now mostly auto-formatted with prettier, and the config for that is really slim, this repo follows these guidelines. To automatically check and adjust the code style,
+
+1. Run `npm run prettier`
+2. Done.
+
 ## License
 
 MPL.

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
   "private": true,
   "scripts": {
     "jake": "./node_modules/.bin/jake",
+    "prettier": "./node_modules/.bin/prettier --write '**/{*.js,*.jsm,Jakefile}'",
     "start": "./node_modules/.bin/web-ext run --source-dir src/",
     "test": "./node_modules/.bin/jasmine"
   },
   "devDependencies": {
     "jake": "^8.1.1",
     "jasmine": "^3.4.0",
+    "prettier": "^1.18.2",
     "web-ext": "^3.1.0"
   }
 }


### PR DESCRIPTION
`mozilla-central` now follows the prettier style guide and uses that tool to autoformat. Since the sources in this repo end up in m-c as well, it makes sense that we have support for running prettier. The config we have in m-c is really slim, so I feel good with just copying it over.

r? @ksy36 