### PR TITLE
Bug 1568908 - Remove duplicate scrollbar in Google Cloud Console.

### DIFF
--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -239,6 +239,21 @@ const AVAILABLE_INJECTIONS = [
       ],
     },
   },
+  {
+    id: "bug1568908",
+    platform: "desktop",
+    domain: "console.cloud.google.com",
+    bug: "1568908",
+    contentScripts: {
+      matches: ["*://*.console.cloud.google.com/*"],
+      css: [
+        {
+          file:
+            "injections/css/bug1568908-console.cloud.google.com-scrollbar-fix.css",
+        },
+      ],
+    },
+  },
 ];
 
 module.exports = AVAILABLE_INJECTIONS;

--- a/src/injections/css/bug1568908-console.cloud.google.com-scrollbar-fix.css
+++ b/src/injections/css/bug1568908-console.cloud.google.com-scrollbar-fix.css
@@ -1,0 +1,16 @@
+/**
+ * console.cloud.google.com - Double scrollbar visisible on long pages
+ * Bug #1568908 - https://bugzilla.mozilla.org/show_bug.cgi?id=1568908
+ * WebCompat issue #33164 - https://webcompat.com/issues/33164
+ *
+ * For pages that have contents heigher than the page's height, a secondary
+ * scrollbar outside the scrollable content area is visible. This is caused
+ * by a difference in Flexbox behavior, which is being addressed in
+ * https://bugs.chromium.org/p/chromium/issues/detail?id=981134
+ *
+ * Until this fix hits release and Google has updated their UI properly,
+ * this intervention addresses the differences.
+ */
+central-page-area {
+  min-height: 0;
+}


### PR DESCRIPTION
This is the fix for https://github.com/webcompat/web-bugs/issues/33164.

r? @ksy36 