### PR TITLE
Bug 1581967 - Modify Gmail intervention to not break menus

### DIFF
--- a/src/injections/css/bug1561371-mail.google.com-allow-horizontal-scrolling.css
+++ b/src/injections/css/bug1561371-mail.google.com-allow-horizontal-scrolling.css
@@ -7,6 +7,6 @@
  * CSS served to Fennec does not permit scrolling horizontally. To prevent
  * this UX frustration, we enable horizontal scrolling.
  */
-body > #views > div {
+body > #views {
   overflow: auto;
 }


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1581967

Fixes https://github.com/webcompat/web-bugs/issues/40308
Fixes https://github.com/webcompat/web-bugs/issues/40312
Fixes https://github.com/webcompat/web-bugs/issues/40151
Fixes https://github.com/webcompat/web-bugs/issues/37687
Fixes https://github.com/webcompat/web-bugs/issues/40236