### PR TITLE
Bug 1585380 - Add support for a control experiment branch

### DIFF
--- a/src/data/ua_overrides.js
+++ b/src/data/ua_overrides.js
@@ -49,7 +49,7 @@ const AVAILABLE_UA_OVERRIDES = [
       blocks: [...getMatchPatternsForGoogleURL("www.google", "serviceworker")],
       permanentPref: "enable_enhanced_search",
       telemetryKey: "enhancedSearch",
-      experiment: "enhanced-search",
+      experiment: ["enhanced-search", "enhanced-search-control"],
       uaTransformer: originalUA => {
         return UAHelpers.getDeviceAppropriateChromeUA();
       },

--- a/src/experiment-apis/sharedPreferences.js
+++ b/src/experiment-apis/sharedPreferences.js
@@ -15,6 +15,12 @@ this.sharedPreferences = class extends ExtensionAPI {
   getAPI(context) {
     return {
       sharedPreferences: {
+        async setCharPref(name, value) {
+          if (!Services.androidBridge || !Services.androidBridge.isFennec) {
+            return;
+          }
+          SharedPreferences.forApp().setCharPref(name, value);
+        },
         async setBoolPref(name, value) {
           if (!Services.androidBridge || !Services.androidBridge.isFennec) {
             return;

--- a/src/experiment-apis/sharedPreferences.json
+++ b/src/experiment-apis/sharedPreferences.json
@@ -20,6 +20,24 @@
           }
         ],
         "async": true
+      },
+      {
+        "name": "setCharPref",
+        "type": "function",
+        "description": "Set the value of a string Fennec SharedPreference",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The key name"
+          },
+          {
+            "name": "value",
+            "type": "string",
+            "description": "The new value"
+          }
+        ],
+        "async": true
       }
     ]
   }

--- a/src/lib/injections.js
+++ b/src/lib/injections.js
@@ -96,7 +96,9 @@ class Injections {
       injection.active = true;
     } else {
       console.error(
-        `Provided function ${injection.customFunc} wasn't found in functions list`
+        `Provided function ${
+          injection.customFunc
+        } wasn't found in functions list`
       );
     }
   }

--- a/src/lib/ua_overrides.js
+++ b/src/lib/ua_overrides.js
@@ -54,6 +54,15 @@ class UAOverrides {
 
     const { blocks, matches, telemetryKey, uaTransformer } = override.config;
     const listener = details => {
+      // We set the "used" telemetry key if the user would have had the
+      // override applied, regardless of whether it is actually applied.
+      if (!details.frameId && override.shouldSendDetailedTelemetry) {
+        // For now, we only care about Telemetry on Fennec, where telemetry
+        // is sent in Java code (as part of the core ping). That code must
+        // be aware of each key we send, which we send as a SharedPreference.
+        browser.sharedPreferences.setBoolPref(`${telemetryKey}Used`, true);
+      }
+
       // Don't actually override the UA for an experiment if the user is not
       // part of the experiment (unless they force-enabed the override).
       if (
@@ -61,13 +70,6 @@ class UAOverrides {
         override.experimentActive ||
         override.permanentPrefEnabled === true
       ) {
-        if (telemetryKey && !details.frameId) {
-          // For now, we only care about Telemetry on Fennec, where telemetry
-          // is sent in Java code (as part of the core ping). That code must
-          // be aware of each key we send, which we send as a SharedPreference.
-          browser.sharedPreferences.setBoolPref(`${telemetryKey}Used`, true);
-        }
-
         for (const header of details.requestHeaders) {
           if (header.name.toLowerCase() === "user-agent") {
             header.value = uaTransformer(header.value);
@@ -100,8 +102,14 @@ class UAOverrides {
     this._activeListeners.set(override, listeners);
     override.active = true;
 
-    // If collecting telemetry on the override, note that it was activated.
+    // If telemetry is being collected, note the addon version.
     if (telemetryKey) {
+      const { version } = browser.runtime.getManifest();
+      browser.sharedPreferences.setCharPref(`${telemetryKey}Version`, version);
+    }
+
+    // If collecting detailed telemetry on the override, note that it was activated.
+    if (override.shouldSendDetailedTelemetry) {
       browser.sharedPreferences.setBoolPref(`${telemetryKey}Ready`, true);
     }
   }
@@ -127,6 +135,12 @@ class UAOverrides {
     if (override.permanentPrefEnabled === false) {
       shouldBeActive = false;
     }
+
+    // Only send detailed telemetry if the user is actively in an experiment or
+    // has opted into an experimental feature.
+    override.shouldSendDetailedTelemetry =
+      override.config.telemetryKey &&
+      (override.experimentActive || override.permanentPrefEnabled);
 
     // Overrides gated behind an experiment the user is not part of do not
     // have to be activated, unless they are gathering telemetry, or the
@@ -164,11 +178,23 @@ class UAOverrides {
       if (platformMatches.includes(override.platform)) {
         override.availableOnPlatform = true;
 
-        // If there is a specific experiment running for
-        // this override, get its state.
+        // Note whether the user is actively in the override's experiment (if any).
+        override.experimentActive = false;
         const experiment = override.config.experiment;
-        override.experimentActive =
-          experiment && (await browser.experiments.isActive(experiment));
+        if (experiment) {
+          // We expect the definition to have either one string for 'experiment'
+          // (just one branch) or an array of strings (multiple branches). So
+          // here we turn the string case into a one-element array for the loop.
+          const branches = Array.isArray(experiment)
+            ? experiment
+            : [experiment];
+          for (const branch of branches) {
+            if (await browser.experiments.isActive(branch)) {
+              override.experimentActive = true;
+              break;
+            }
+          }
+        }
 
         // If there is a specific about:config preference governing
         // this override, monitor its state.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Web Compat",
   "description": "Urgent post-release fixes for web compatibility.",
-  "version": "6.1.0",
+  "version": "6.3.0",
 
   "applications": {
     "gecko": {


### PR DESCRIPTION
This adds a control experiment branch for the enhanced search feature, as well as having it emit the addon version to fennec telemetry, and only send extra telemetry when a user is in the experiment (or triggers the testing pref).

Note there is also a minor change injections.js to keep mach lint from complaining.

Also note that any necessary companion changes to the Fennec java files will be made in a separate patch on bug 1585380.