### PR TITLE
Bug 1605611 - `npm run prettier`-run to prevent styleguide backouts on mozilla-central.

### DIFF
--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -441,8 +441,8 @@ const AVAILABLE_INJECTIONS = [
       js: [
         {
           file: "injections/js/bug1605611-maps.google.com-directions-time.js",
-        }
-      ]
+        },
+      ],
     },
   },
 ];

--- a/src/injections/css/bug1605611-maps.google.com-directions-time.css
+++ b/src/injections/css/bug1605611-maps.google.com-directions-time.css
@@ -11,7 +11,8 @@
  * the native date picker when they tap on the relevant UI in Google Maps.
  */
 
-.ml-route-options-picker-content-button > #ml-route-options-time-selector-time-input {
+.ml-route-options-picker-content-button
+  > #ml-route-options-time-selector-time-input {
   z-index: 1; /* overrides -5000, to show on top of the icon AND the rendered date */
   opacity: 0; /* let the input element be fully transparent */
   width: 100vw; /* render over the rendered date from Maps' dialog */

--- a/src/injections/js/bug1605611-maps.google.com-directions-time.js
+++ b/src/injections/js/bug1605611-maps.google.com-directions-time.js
@@ -17,7 +17,9 @@
 // Step 1.
 document.addEventListener("DOMContentLoaded", () => {
   // In case the element appeared before the MutationObserver was activated.
-  for (const elem of document.querySelectorAll('.ml-directions-time[disabled]')) {
+  for (const elem of document.querySelectorAll(
+    ".ml-directions-time[disabled]"
+  )) {
     elem.disabled = false;
   }
   // Start watching for the insertion of the "Leave now" button.
@@ -44,7 +46,6 @@ document.addEventListener("DOMContentLoaded", () => {
   mo.observe(document.body, moOptions);
 });
 
-
 // Step 2.
 const originalValueAsNumberGetter = Object.getOwnPropertyDescriptor(
   HTMLInputElement.prototype.wrappedJSObject,
@@ -52,13 +53,13 @@ const originalValueAsNumberGetter = Object.getOwnPropertyDescriptor(
 ).get;
 Object.defineProperty(
   HTMLInputElement.prototype.wrappedJSObject,
-  'valueAsNumber',
+  "valueAsNumber",
   {
     configurable: true,
     enumerable: true,
     get: originalValueAsNumberGetter,
     set: exportFunction(function(v) {
-      if (this.type === 'datetime-local' && v) {
+      if (this.type === "datetime-local" && v) {
         const d = new Date(v);
         d.setSeconds(0);
         d.setMilliseconds(0);
@@ -68,7 +69,6 @@ Object.defineProperty(
     }, window),
   }
 );
-
 
 // Step 3.
 // injections/css/bug1605611-maps.google.com-directions-time.css fixes the bug,


### PR DESCRIPTION
This is a style-only PR to prevent build-errors and backouts when trying to land this stuff.

r? @ksy36 