### PR TITLE
Run codestyle checks on CI, and other goodies.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,46 @@
 version: 2
 jobs:
-  build:
+  specs:
     docker:
       - image: circleci/node:12.6.0
-    working_directory: ~/repo
     steps:
       - checkout
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
             - v1-dependencies-
-      - run: npm install
+      - run:
+          name: Unit tests (Jasmine)
+          command: |
+            npm install
+            npm run jasmine
       - save_cache:
+          key: v1-dependencies-{{ checksum "package.json" }}
           paths:
             - node_modules
+
+  codestyle:
+    docker:
+      - image: circleci/node:12.6.0
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+      - run:
+          name: Codestyle verification (Prettier)
+          command: |
+            npm install
+            npm run prettier-check
+      - save_cache:
           key: v1-dependencies-{{ checksum "package.json" }}
-      - run: npm test
+          paths:
+            - node_modules
+
+workflows:
+  version: 2
+  run_tests:
+    jobs:
+      - specs
+      - codestyle

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+echo "Installing dependencies to run the pre-push check..."
+if ! npm install > /dev/null 2> /dev/null; then
+  echo "!! Installing dependencies failed! Please run 'npm install' to see what's wrong."
+  exit 1
+fi
+
+echo "Running unit tests..."
+if ! npm run --silent jasmine > /dev/null 2> /dev/null; then
+  echo "!! Running unit tests returned an error! Please run 'npm run jasmine' to see what's wrong."
+  exit 1
+fi
+
+echo "Running codestyle checks..."
+if ! npm run --silent prettier-check > /dev/null 2> /dev/null; then
+  echo "!! Running codestyle checks returned an error! Please run 'npm run prettier-check' to see what's wrong."
+  exit 1
+fi
+
+echo "All good, continuing the push!"

--- a/Jakefile
+++ b/Jakefile
@@ -88,7 +88,7 @@ function replaceFilelistPlaceholders(cssInjections, jsInjections) {
   return new Promise((resolve, reject) => {
     let formatList = files => {
       files = files.map(filename => filename.replace("build/", ""));
-      return "'" + files.join("',\n  '") + "'";
+      return "'" + files.join("',\n  '") + "',";
     };
 
     let mozBuildFilename = path.join(BUILD_DIR, "moz.build");

--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ As `mozilla-central` is now mostly auto-formatted with prettier, and the config 
 1. Run `npm run prettier`
 2. Done.
 
+### Run tests and codestyle checks automatically before pushing
+
+If you want to make sure you don't push something that would fail on CI, use the `pre-push` hook supplied with this repository.
+
+If your Git version is newer than 2.9.x, you can enable the hooks with
+
+```
+git config core.hooksPath .githooks
+```
+
+and if Git is older, please symlink the hook into the right directory manually with
+
+```
+ln -s .githooks/pre-push .git/hooks/
+```
+
 ## License
 
 MPL.

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "test": "./node_modules/.bin/jasmine"
   },
   "devDependencies": {
-    "jake": "^8.1.1",
-    "jasmine": "^3.4.0",
+    "jake": "^10.4.3",
+    "jasmine": "^3.5.0",
     "prettier": "1.17.0",
-    "web-ext": "^3.1.0"
+    "web-ext": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "jake": "./node_modules/.bin/jake",
-    "prettier": "./node_modules/.bin/prettier --write '**/{*.css,*.js,*.jsm,Jakefile}'",
-    "start": "./node_modules/.bin/web-ext run --source-dir src/",
-    "test": "./node_modules/.bin/jasmine"
+    "jake": "npx jake",
+    "prettier": "npx prettier --write '**/{*.css,*.js,*.jsm,Jakefile}'",
+    "start": "npx web-ext run --source-dir src/",
+    "test": "npx jasmine"
   },
   "devDependencies": {
     "jake": "^10.4.3",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
   "private": true,
   "scripts": {
     "jake": "npx jake",
+    "prettier-check": "npx prettier --check '**/{*.css,*.js,*.jsm,Jakefile}'",
     "prettier": "npx prettier --write '**/{*.css,*.js,*.jsm,Jakefile}'",
+    "jasmine": "npx jasmine",
     "start": "npx web-ext run --source-dir src/",
-    "test": "npx jasmine"
+    "test": "npm run jasmine && npm run prettier-check"
   },
   "devDependencies": {
     "jake": "^10.4.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "jake": "^8.1.1",
     "jasmine": "^3.4.0",
-    "prettier": "^1.18.2",
+    "prettier": "1.17.0",
     "web-ext": "^3.1.0"
   }
 }

--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -441,8 +441,8 @@ const AVAILABLE_INJECTIONS = [
       js: [
         {
           file: "injections/js/bug1605611-maps.google.com-directions-time.js",
-        }
-      ]
+        },
+      ],
     },
   },
 ];

--- a/src/injections/css/bug1605611-maps.google.com-directions-time.css
+++ b/src/injections/css/bug1605611-maps.google.com-directions-time.css
@@ -11,7 +11,8 @@
  * the native date picker when they tap on the relevant UI in Google Maps.
  */
 
-.ml-route-options-picker-content-button > #ml-route-options-time-selector-time-input {
+.ml-route-options-picker-content-button
+  > #ml-route-options-time-selector-time-input {
   z-index: 1; /* overrides -5000, to show on top of the icon AND the rendered date */
   opacity: 0; /* let the input element be fully transparent */
   width: 100vw; /* render over the rendered date from Maps' dialog */

--- a/src/injections/js/bug1605611-maps.google.com-directions-time.js
+++ b/src/injections/js/bug1605611-maps.google.com-directions-time.js
@@ -17,7 +17,9 @@
 // Step 1.
 document.addEventListener("DOMContentLoaded", () => {
   // In case the element appeared before the MutationObserver was activated.
-  for (const elem of document.querySelectorAll('.ml-directions-time[disabled]')) {
+  for (const elem of document.querySelectorAll(
+    ".ml-directions-time[disabled]"
+  )) {
     elem.disabled = false;
   }
   // Start watching for the insertion of the "Leave now" button.
@@ -44,7 +46,6 @@ document.addEventListener("DOMContentLoaded", () => {
   mo.observe(document.body, moOptions);
 });
 
-
 // Step 2.
 const originalValueAsNumberGetter = Object.getOwnPropertyDescriptor(
   HTMLInputElement.prototype.wrappedJSObject,
@@ -52,13 +53,13 @@ const originalValueAsNumberGetter = Object.getOwnPropertyDescriptor(
 ).get;
 Object.defineProperty(
   HTMLInputElement.prototype.wrappedJSObject,
-  'valueAsNumber',
+  "valueAsNumber",
   {
     configurable: true,
     enumerable: true,
     get: originalValueAsNumberGetter,
     set: exportFunction(function(v) {
-      if (this.type === 'datetime-local' && v) {
+      if (this.type === "datetime-local" && v) {
         const d = new Date(v);
         d.setSeconds(0);
         d.setMilliseconds(0);
@@ -68,7 +69,6 @@ Object.defineProperty(
     }, window),
   }
 );
-
 
 // Step 3.
 // injections/css/bug1605611-maps.google.com-directions-time.css fixes the bug,


### PR DESCRIPTION
This PR does a couple of things.

* Downgrades `prettier` to the [version in use inside `mozilla-central`](https://searchfox.org/mozilla-central/rev/be7d1f2d52dd9474ca2df145190a817614c924e4/package.json#24), because different `prettier` versions do different things occasionally...
* Updates dev dependencies - mainly to remove an annoying security warning.
* Changes the CircleCI configs so that stylecheck failures will now turn a PR red.
* Fixes existing codestyle violations, as the PR would fail otherwise.
* Supplies a `pre-push` hook that runs jasmine tests and codestyle verifications, as well as adds documentation on how to use the hook. I wanted to use a `pre-commit` hook first, but since the whole process takes a bit of time, I decided against that.
* Changes the `jake` exporter so that the auto-generated file lists in `moz.build` have trailing commas. All other lists in that file have trailing commas, so the auto-generated ones are the odd ones. This does not cause style check errors in m-c, but let's change it anyway for the sake of consistency. 

r? @ksy36 

Closes #96.