### PR TITLE
Bug 1442050 - Add `AppleWebKit` identifer to UA on my.nintendo.com.

### DIFF
--- a/src/data/ua_overrides.js
+++ b/src/data/ua_overrides.js
@@ -647,6 +647,27 @@ const AVAILABLE_UA_OVERRIDES = [
       },
     },
   },
+  {
+    /*
+     * Bug 1442050 - UA overrides for Uniqlo sites
+     * Webcompat issue #12887 - https://webcompat.com/issues/12887
+     *
+     * Nintendo ships a broken version of their mobile interface to mobile
+     * browsers that are not Chrome or Safari. In our tests, appending the
+     * "AppleWebKit" identifier to the UA string results in a version that
+     * works very well.
+     */
+    id: "bug1442050",
+    platform: "android",
+    domain: "nintendo.com",
+    bug: "1442050",
+    config: {
+      matches: ["*://my.nintendo.com/*"],
+      uaTransformer: originalUA => {
+        return originalUA + " AppleWebKit";
+      },
+    },
+  },
 ];
 
 const UAHelpers = {


### PR DESCRIPTION
This is for [bug 1442050](https://bugzilla.mozilla.org/show_bug.cgi?id=1442050). Simply appending the identifier to our UA works fine.

r? @ksy36 