### PR TITLE
Bug 1610344 - Hide "Browser is not supported" message on directv.com.co.

### DIFF
--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -444,6 +444,21 @@ const AVAILABLE_INJECTIONS = [
       ],
     },
   },
+  {
+    id: "bug1610344",
+    platform: "android",
+    domain: "directv.com.co",
+    bug: "1610344",
+    contentScripts: {
+      matches: ["https://*.directv.com.co/*"],
+      css: [
+        {
+          file:
+            "injections/css/bug1610344-directv.com.co-hide-unsupported-message.css",
+        },
+      ],
+    },
+  },
 ];
 
 module.exports = AVAILABLE_INJECTIONS;

--- a/src/injections/css/bug1610344-directv.com.co-hide-unsupported-message.css
+++ b/src/injections/css/bug1610344-directv.com.co-hide-unsupported-message.css
@@ -1,0 +1,13 @@
+/**
+ * directv.com.co - Browser is not supported message
+ * Bug #1610344 - https://bugzilla.mozilla.org/show_bug.cgi?id=1610344
+ * WebCompat issue #41822 - https://webcompat.com/issues/41822
+ *
+ * directv.com.co is showing a "This browser is not supported" message in
+ * Firefox. Our tests indicated that everything is working just fine, and our
+ * previous contact attempts have not been successful. This intervention
+ * hides the large red unsupported banner.
+ */
+.browser-compatible.compatible.incompatible {
+  display: none;
+}


### PR DESCRIPTION
See also [bug 1610344](https://bugzilla.mozilla.org/show_bug.cgi?id=1610344).

r? @ksy36 