### PR TITLE
Bug 1614068 - Apply Picture-in-Picture toggle policy to laracasts.com sites.

### DIFF
--- a/src/data/picture_in_picture_overrides.js
+++ b/src/data/picture_in_picture_overrides.js
@@ -25,6 +25,9 @@ let AVAILABLE_PIP_OVERRIDES;
     // Instagram
     "https://www.instagram.com/*": TOGGLE_POLICIES.ONE_QUARTER,
 
+    // Laracasts
+    "https://*.laracasts.com/*": TOGGLE_POLICIES.ONE_QUARTER,
+    
     // Twitch
     "https://*.twitch.tv/*": TOGGLE_POLICIES.ONE_QUARTER,
     "https://*.twitch.tech/*": TOGGLE_POLICIES.ONE_QUARTER,


### PR DESCRIPTION
This positions the toggle at one quarter from the top of the video, to avoid
the "next video" carousel button on laracasts.com.