### PR TITLE
Bug 1620218 - Upgrade Prettier to 1.18.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "jake": "^10.4.3",
     "jasmine": "^3.5.0",
-    "prettier": "1.17.0",
+    "prettier": "1.18.2",
     "web-ext": "^4.0.0"
   }
 }

--- a/src/lib/injections.js
+++ b/src/lib/injections.js
@@ -96,9 +96,7 @@ class Injections {
       injection.active = true;
     } else {
       console.error(
-        `Provided function ${
-          injection.customFunc
-        } wasn't found in functions list`
+        `Provided function ${injection.customFunc} wasn't found in functions list`
       );
     }
   }


### PR DESCRIPTION
This is a preparation so we're ready whenever the changes happen on `mozilla-central`. Do not merge this PR before [bug 1620218](https://bugzilla.mozilla.org/show_bug.cgi?id=1620218) is landed.