### PR TITLE
Bug 1621065 - Write UA override for bracketchallenge.ncaa.com

### DIFF
--- a/src/data/ua_overrides.js
+++ b/src/data/ua_overrides.js
@@ -586,6 +586,27 @@ const AVAILABLE_UA_OVERRIDES = [
       },
     },
   },
+  {
+    /*
+     * Bug 1621065 - UA overrides for bracketchallenge.ncaa.com
+     * Webcompat issue #49886 - https://webcompat.com/issues/49886
+     *
+     * The NCAA bracket challenge website mistakenly classifies
+     * any non-Chrome browser on Android as "is_old_android". As a result,
+     * a modal is shown telling them they have security flaws. We have
+     * attempted to reach out for a fix (and clarification).
+     */
+    id: "bug1621065",
+    platform: "android",
+    domain: "bracketchallenge.ncaa.com",
+    bug: "1621065",
+    config: {
+      matches: ["*://bracketchallenge.ncaa.com/*"],
+      uaTransformer: originalUA => {
+        return originalUA + " Chrome";
+      },
+    },
+  },
 ];
 
 const UAHelpers = {


### PR DESCRIPTION
If we don't have "Chrome" in the UA string, we're detected as
an older version of Android and our users get a scary modal.

I've tested locally on Fennec and the Sample browser from AC.

r? @ksy36 