### PR TITLE
Bug 1620556 - Upgrade Prettier to 1.19.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "jake": "^10.4.3",
     "jasmine": "^3.5.0",
-    "prettier": "1.18.2",
+    "prettier": "1.19.1",
     "web-ext": "^4.0.0"
   }
 }

--- a/src/about-compat/AboutCompat.jsm
+++ b/src/about-compat/AboutCompat.jsm
@@ -27,11 +27,10 @@ AboutCompat.prototype = {
     const channel = Services.io.newChannelFromURIWithLoadInfo(uri, aLoadInfo);
     channel.originalURI = aURI;
 
-    channel.owner = (Services.scriptSecurityManager.createContentPrincipal ||
-      Services.scriptSecurityManager.createCodebasePrincipal)(
-      uri,
-      aLoadInfo.originAttributes
-    );
+    channel.owner = (
+      Services.scriptSecurityManager.createContentPrincipal ||
+      Services.scriptSecurityManager.createCodebasePrincipal
+    )(uri, aLoadInfo.originAttributes);
     return channel;
   },
 };


### PR DESCRIPTION
This will stay a draft PR until [this Phabricator revisoin](https://phabricator.services.mozilla.com/D66128) is landed. It's likely this will need a quick rebase with the upcoming changes to this addon, but it shouldn't be too bad (the second commit is automated via `npm run prettier` anyway. :))