### PR TITLE
Also run prettier on .json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "private": true,
   "scripts": {
     "jake": "npx jake",
-    "prettier-check": "npx prettier --check '**/{*.css,*.js,*.jsm,Jakefile}'",
-    "prettier": "npx prettier --write '**/{*.css,*.js,*.jsm,Jakefile}'",
+    "prettier-check": "npx prettier --check '**/{*.css,*.js,*.jsm,*.json,Jakefile}'",
+    "prettier": "npx prettier --write '**/{*.css,*.js,*.jsm,*.json,Jakefile}'",
     "jasmine": "npx jasmine",
     "start": "npx web-ext run --source-dir src/",
     "test": "npm run jasmine && npm run prettier-check"

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,11 +1,7 @@
 {
   "spec_dir": "spec",
-  "spec_files": [
-    "**/*[sS]pec.js"
-  ],
-  "helpers": [
-    "helpers/**/*.js"
-  ],
+  "spec_files": ["**/*[sS]pec.js"],
+  "helpers": ["helpers/**/*.js"],
   "stopSpecOnExpectationFailure": false,
   "random": true
 }

--- a/src/about-compat/aboutPage.json
+++ b/src/about-compat/aboutPage.json
@@ -1,4 +1,6 @@
-[{
+[
+  {
     "namespace": "aboutCompat",
     "description": "Enables the about:compat page"
-}]
+  }
+]

--- a/src/experiment-apis/aboutConfigPrefs.json
+++ b/src/experiment-apis/aboutConfigPrefs.json
@@ -6,16 +6,20 @@
       {
         "name": "onPrefChange",
         "type": "function",
-        "parameters": [{
-          "name": "name",
-          "type": "string",
-          "description": "The preference which changed"
-        }],
-        "extraParameters": [{
-          "name": "name",
-          "type": "string",
-          "description": "The preference to monitor"
-        }]
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference which changed"
+          }
+        ],
+        "extraParameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference to monitor"
+          }
+        ]
       }
     ],
     "functions": [
@@ -23,11 +27,13 @@
         "name": "getPref",
         "type": "function",
         "description": "Get a preference's value",
-        "parameters": [{
-          "name": "name",
-          "type": "string",
-          "description": "The preference name"
-        }],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference name"
+          }
+        ],
         "async": true
       },
       {


### PR DESCRIPTION
mozilla-central is not (yet?) doing that, but since prettier can work on .json files and is doing a fairly good job of keeping them readable, let's remove one additional point of ambiguity and have our embedded prettier do the job for us.

r? @miketaylr 