### PR TITLE
Bug 1546051 - Hide PiP on Netflix previews

### DIFF
--- a/src/data/picture_in_picture_overrides.js
+++ b/src/data/picture_in_picture_overrides.js
@@ -28,6 +28,9 @@ let AVAILABLE_PIP_OVERRIDES;
     // Laracasts
     "https://*.laracasts.com/*": TOGGLE_POLICIES.ONE_QUARTER,
 
+    // Netflix
+    "https://*.netflix.com/browse": TOGGLE_POLICIES.HIDDEN,
+
     // Twitch
     "https://*.twitch.tv/*": TOGGLE_POLICIES.ONE_QUARTER,
     "https://*.twitch.tech/*": TOGGLE_POLICIES.ONE_QUARTER,


### PR DESCRIPTION
OK, so Netflix has a lot of domains. I've tested all of these (via curl and commandline fetch hax), cobbled from a few sources. I'm slightly concerned that we're increasing memory usage by adding 200 new PiP policy overrides for all our users, when they likely only need this for a single Netflix TLD.

r? @denschub 

Also cc @adamopenweb, just to see if he thinks we should trim the list of Netflix domains.