### PR TITLE
Bug 1641998 - Overwride IndexedDB APIs for embedded Twitter videos.

### DIFF
--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -440,6 +440,22 @@ const AVAILABLE_INJECTIONS = [
       ],
     },
   },
+  {
+    id: "bug1641998",
+    platform: "desktop",
+    domain: "twitter.com",
+    bug: "1641998",
+    contentScripts: {
+      matches: ["https://twitter.com/i/videos/tweet/*"],
+      allFrames: true,
+      js: [
+        {
+          file:
+            "injections/js/bug1641998-embedded-twitter-videos-etp-indexeddb.js",
+        },
+      ],
+    },
+  },
 ];
 
 module.exports = AVAILABLE_INJECTIONS;

--- a/src/injections/js/bug1641998-embedded-twitter-videos-etp-indexeddb.js
+++ b/src/injections/js/bug1641998-embedded-twitter-videos-etp-indexeddb.js
@@ -1,0 +1,24 @@
+"use strict";
+
+/**
+ * Bug 1641998 - Embedded Twitter videos - Override indexedDB API
+ * See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1641521
+ *
+ * With ETP enabled, embedded Twitter videos break. This is caused by Twitter
+ * trying to access the indexedDB API for testing if the API is there, without
+ * anticipating the potential for a SecurityError to be thrown.
+ *
+ * This site patch sets window.indexedDB to undefined so their detection can
+ * work correctly.
+ */
+
+/* globals exportFunction */
+
+console.info(
+  "window.indexedDB has been overwritten for compatibility reasons. See https://bugzilla.mozilla.org/show_bug.cgi?id=1641521 for details."
+);
+
+Object.defineProperty(window.wrappedJSObject, "indexedDB", {
+  get: undefined,
+  set: undefined,
+});


### PR DESCRIPTION
Follow-up to yesterday, as I didn't get required information in time.

r? @ksy36 